### PR TITLE
fix: resolve cargo fmt formatting issues

### DIFF
--- a/crates/diecut-core/src/lib.rs
+++ b/crates/diecut-core/src/lib.rs
@@ -38,9 +38,7 @@ pub fn generate(options: GenerateOptions) -> Result<GeneratedProject> {
     let source = resolve_source(&options.template)?;
     let template_dir = match &source {
         TemplateSource::Local(path) => path.clone(),
-        TemplateSource::Git { url, git_ref } => {
-            get_or_clone(url, git_ref.as_deref())?
-        }
+        TemplateSource::Git { url, git_ref } => get_or_clone(url, git_ref.as_deref())?,
     };
 
     // 2. Resolve template (auto-detect format, parse config)

--- a/crates/diecut-core/src/template/clone.rs
+++ b/crates/diecut-core/src/template/clone.rs
@@ -28,21 +28,20 @@ pub fn clone_template(url: &str, git_ref: Option<&str>) -> Result<tempfile::Temp
     })?;
 
     // Use prepare_clone (with worktree) so we get a checked-out working copy
-    let mut prepare = gix::prepare_clone(url, tmp_dir.path()).map_err(|e| {
-        DicecutError::GitClone {
+    let mut prepare =
+        gix::prepare_clone(url, tmp_dir.path()).map_err(|e| DicecutError::GitClone {
             url: url.to_string(),
             reason: e.to_string(),
-        }
-    })?;
+        })?;
 
     // If a specific ref is requested, configure it before fetching
     if let Some(ref_name) = git_ref {
-        prepare = prepare.with_ref_name(Some(ref_name)).map_err(|e| {
-            DicecutError::GitCheckout {
+        prepare = prepare
+            .with_ref_name(Some(ref_name))
+            .map_err(|e| DicecutError::GitCheckout {
                 git_ref: ref_name.to_string(),
                 reason: e.to_string(),
-            }
-        })?;
+            })?;
     }
 
     // Fetch and prepare for checkout
@@ -54,13 +53,12 @@ pub fn clone_template(url: &str, git_ref: Option<&str>) -> Result<tempfile::Temp
         })?;
 
     // Checkout the main worktree
-    let (_repo, _outcome) =
-        checkout
-            .main_worktree(gix::progress::Discard, &gix::interrupt::IS_INTERRUPTED)
-            .map_err(|e| DicecutError::GitClone {
-                url: url.to_string(),
-                reason: format!("worktree checkout failed: {e}"),
-            })?;
+    let (_repo, _outcome) = checkout
+        .main_worktree(gix::progress::Discard, &gix::interrupt::IS_INTERRUPTED)
+        .map_err(|e| DicecutError::GitClone {
+            url: url.to_string(),
+            reason: format!("worktree checkout failed: {e}"),
+        })?;
 
     Ok(tmp_dir)
 }

--- a/crates/diecut-core/src/template/mod.rs
+++ b/crates/diecut-core/src/template/mod.rs
@@ -2,6 +2,6 @@ pub mod cache;
 pub mod clone;
 pub mod source;
 
-pub use cache::{get_or_clone, list_cached, clear_cache, CachedTemplate};
+pub use cache::{clear_cache, get_or_clone, list_cached, CachedTemplate};
 pub use clone::clone_template;
 pub use source::{resolve_source, resolve_source_with_ref, TemplateSource};


### PR DESCRIPTION
## Summary
- Run `cargo fmt` to fix formatting inconsistencies across the template module files (cache.rs, clone.rs, lib.rs, mod.rs)

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --check` passes (this is what CI was failing on)