### PR TITLE
feat: add diecut list command and user config

### DIFF
--- a/crates/diecut-cli/src/cli.rs
+++ b/crates/diecut-cli/src/cli.rs
@@ -39,6 +39,9 @@ pub enum Commands {
         no_hooks: bool,
     },
 
+    /// List cached templates
+    List,
+
     /// Validate a template directory
     Check {
         /// Path to the template to check (default: current directory)

--- a/crates/diecut-cli/src/commands/list.rs
+++ b/crates/diecut-cli/src/commands/list.rs
@@ -1,0 +1,67 @@
+use console::style;
+use miette::Result;
+
+use diecut_core::template::{list_cached, CachedTemplate};
+
+pub fn run() -> Result<()> {
+    let entries = list_cached()?;
+
+    if entries.is_empty() {
+        println!(
+            "No cached templates. Use '{}' with a git URL to cache templates.",
+            style("diecut new").cyan()
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{} ({} template{})\n",
+        style("Cached templates").bold(),
+        entries.len(),
+        if entries.len() == 1 { "" } else { "s" }
+    );
+
+    for entry in &entries {
+        print_entry(entry);
+    }
+
+    Ok(())
+}
+
+fn print_entry(entry: &CachedTemplate) {
+    let git_ref = entry.metadata.git_ref.as_deref().unwrap_or("default");
+
+    let cached_at = format_timestamp(&entry.metadata.cached_at);
+
+    println!("  {} {}", style("source:").dim(), entry.metadata.url);
+    println!("  {}    {}", style("ref:").dim(), git_ref);
+    println!("  {} {}", style("cached:").dim(), cached_at);
+    println!();
+}
+
+fn format_timestamp(unix_ts: &str) -> String {
+    let secs: u64 = match unix_ts.parse() {
+        Ok(s) => s,
+        Err(_) => return unix_ts.to_string(),
+    };
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let elapsed = now.saturating_sub(secs);
+
+    if elapsed < 60 {
+        "just now".to_string()
+    } else if elapsed < 3600 {
+        let mins = elapsed / 60;
+        format!("{mins} minute{} ago", if mins == 1 { "" } else { "s" })
+    } else if elapsed < 86400 {
+        let hours = elapsed / 3600;
+        format!("{hours} hour{} ago", if hours == 1 { "" } else { "s" })
+    } else {
+        let days = elapsed / 86400;
+        format!("{days} day{} ago", if days == 1 { "" } else { "s" })
+    }
+}

--- a/crates/diecut-cli/src/commands/mod.rs
+++ b/crates/diecut-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod check;
+pub mod list;
 pub mod migrate;
 pub mod new;

--- a/crates/diecut-cli/src/main.rs
+++ b/crates/diecut-cli/src/main.rs
@@ -14,6 +14,7 @@ fn main() -> miette::Result<()> {
             overwrite,
             no_hooks,
         } => commands::new::run(template, output, data, defaults, overwrite, no_hooks),
+        Commands::List => commands::list::run(),
         Commands::Check { path } => commands::check::run(path),
         Commands::Migrate {
             path,

--- a/crates/diecut-core/src/config/mod.rs
+++ b/crates/diecut-core/src/config/mod.rs
@@ -1,4 +1,5 @@
 pub mod schema;
+pub mod user;
 pub mod variable;
 
 use std::path::Path;
@@ -6,6 +7,7 @@ use std::path::Path;
 use crate::error::{DicecutError, Result};
 
 pub use schema::TemplateConfig;
+pub use user::{load_user_config, UserConfig};
 
 /// Load and validate a TemplateConfig from a diecut.toml file.
 pub fn load_config(path: &Path) -> Result<TemplateConfig> {

--- a/crates/diecut-core/src/config/user.rs
+++ b/crates/diecut-core/src/config/user.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{DicecutError, Result};
+
+/// User-level configuration loaded from `~/.config/diecut/config.toml`.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct UserConfig {
+    /// Custom abbreviation mappings. Keys are prefixes (e.g. `"company"`),
+    /// values are URL templates with `{}` as placeholder (e.g.
+    /// `"https://git.company.com/{}.git"`).
+    #[serde(default)]
+    pub abbreviations: HashMap<String, String>,
+}
+
+/// Get the path to the user config file.
+fn config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("diecut").join("config.toml"))
+}
+
+/// Load user configuration from the XDG config directory.
+///
+/// Returns `Ok(None)` if the config file does not exist.
+/// Returns `Err` if the file exists but cannot be read or parsed.
+pub fn load_user_config() -> Result<Option<UserConfig>> {
+    let path = match config_path() {
+        Some(p) => p,
+        None => return Ok(None),
+    };
+
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let content = std::fs::read_to_string(&path).map_err(|e| DicecutError::Io {
+        context: format!("reading user config {}", path.display()),
+        source: e,
+    })?;
+
+    let config: UserConfig =
+        toml::from_str(&content).map_err(|e| DicecutError::ConfigParse { source: e })?;
+
+    Ok(Some(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_user_config() {
+        let toml_str = r#"
+[abbreviations]
+company = "https://git.company.com/{}.git"
+internal = "https://internal.example.com/repos/{}"
+"#;
+        let config: UserConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.abbreviations.len(), 2);
+        assert_eq!(
+            config.abbreviations["company"],
+            "https://git.company.com/{}.git"
+        );
+        assert_eq!(
+            config.abbreviations["internal"],
+            "https://internal.example.com/repos/{}"
+        );
+    }
+
+    #[test]
+    fn parse_empty_config() {
+        let config: UserConfig = toml::from_str("").unwrap();
+        assert!(config.abbreviations.is_empty());
+    }
+
+    #[test]
+    fn parse_config_without_abbreviations() {
+        let config: UserConfig = toml::from_str("[abbreviations]").unwrap();
+        assert!(config.abbreviations.is_empty());
+    }
+
+    #[test]
+    fn parse_malformed_config_errors() {
+        let result: std::result::Result<UserConfig, _> = toml::from_str("not valid [[ toml");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_user_config_returns_none_when_no_file() {
+        let result = load_user_config();
+        assert!(result.is_ok());
+    }
+}

--- a/crates/diecut-core/src/template/mod.rs
+++ b/crates/diecut-core/src/template/mod.rs
@@ -2,6 +2,6 @@ pub mod cache;
 pub mod clone;
 pub mod source;
 
-pub use cache::{clear_cache, get_or_clone, list_cached, CachedTemplate};
+pub use cache::{clear_cache, get_or_clone, list_cached, CacheMetadata, CachedTemplate};
 pub use clone::clone_template;
-pub use source::{resolve_source, resolve_source_with_ref, TemplateSource};
+pub use source::{resolve_source, resolve_source_full, resolve_source_with_ref, TemplateSource};


### PR DESCRIPTION
## Summary
- Adds `diecut list` subcommand that displays cached templates with source URL, git ref, and human-readable cache time
- Adds user config support at `~/.config/diecut/config.toml` with custom abbreviation mappings
- Adds `resolve_source_full()` for source resolution with user abbreviations that take priority over built-in ones

## Details

### `diecut list`
Shows all cached templates with formatted output including:
- Source URL
- Git ref (or "default" if none)
- Relative time since cached (e.g. "3 hours ago", "2 days ago")

Handles empty cache gracefully with a helpful message.

### User config
Config file at `~/.config/diecut/config.toml` supports:
```toml
[abbreviations]
company = "https://git.company.com/{}.git"
internal = "https://internal.example.com/repos/{}"
```

User abbreviations are checked before built-in ones (`gh:`, `gl:`, `bb:`, `sr:`), allowing overrides.

## Test plan
- [x] User config parsing tests (valid, empty, missing, malformed TOML)
- [x] Custom abbreviation expansion tests (basic, with ref, priority over builtins, empty remainder error, fallthrough)
- [x] All existing tests pass (53 unit + 20 integration)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes