### PR TITLE
feat: M6 template registry (search and publish)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,7 @@ dependencies = [
  "tera",
  "thiserror",
  "toml",
+ "ureq",
  "walkdir",
 ]
 
@@ -609,6 +610,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -2454,7 +2456,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2712,6 +2714,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3401,6 +3404,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf-8",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,6 +3443,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ rhai = { version = "1", features = ["sync"] }
 tempfile = "3"
 gix = { version = "0.72", default-features = false, features = ["blocking-network-client", "blocking-http-transport-reqwest-rust-tls", "worktree-mutation"] }
 sha2 = "0.10"
+ureq = "3"

--- a/crates/diecut-cli/src/cli.rs
+++ b/crates/diecut-cli/src/cli.rs
@@ -49,6 +49,19 @@ pub enum Commands {
         path: String,
     },
 
+    /// Search for diecut templates on GitHub
+    Search {
+        /// Search query
+        query: String,
+    },
+
+    /// Validate a template and show publishing instructions
+    Publish {
+        /// Path to the template to publish (default: current directory)
+        #[arg(default_value = ".")]
+        path: String,
+    },
+
     /// Migrate a foreign template (e.g. cookiecutter) to native diecut format
     Migrate {
         /// Path to the template to migrate (default: current directory)

--- a/crates/diecut-cli/src/commands/mod.rs
+++ b/crates/diecut-cli/src/commands/mod.rs
@@ -2,3 +2,5 @@ pub mod check;
 pub mod list;
 pub mod migrate;
 pub mod new;
+pub mod publish;
+pub mod search;

--- a/crates/diecut-cli/src/commands/publish.rs
+++ b/crates/diecut-cli/src/commands/publish.rs
@@ -1,0 +1,50 @@
+use std::path::Path;
+
+use console::style;
+use miette::Result;
+
+use diecut_core::check::check_template;
+
+pub fn run(path: String) -> Result<()> {
+    let template_dir = Path::new(&path);
+
+    println!(
+        "{} {}",
+        style("Validating template at").bold(),
+        style(template_dir.display()).cyan()
+    );
+
+    let result = check_template(template_dir)?;
+
+    if !result.warnings.is_empty() {
+        println!("\n{}", style("Warnings:").yellow().bold());
+        for w in &result.warnings {
+            println!("  {} {}", style("⚠").yellow(), w);
+        }
+    }
+
+    if !result.errors.is_empty() {
+        println!("\n{}", style("Errors:").red().bold());
+        for e in &result.errors {
+            println!("  {} {}", style("✗").red(), e);
+        }
+        println!(
+            "\n{} Template has {} error(s) — fix them before publishing",
+            style("✗").red().bold(),
+            result.errors.len()
+        );
+        std::process::exit(1);
+    }
+
+    println!("\n{} Template is valid!\n", style("✓").green().bold());
+    println!("To publish your template:");
+    println!("  1. Push to a GitHub repository");
+    println!(
+        "  2. Add the topic '{}' to your repo (Settings → Topics)",
+        style("diecut-template").cyan()
+    );
+    println!("  3. Others can discover it: diecut search <name>");
+    println!("  4. Others can use it:     diecut new gh:<owner>/<repo>");
+
+    Ok(())
+}

--- a/crates/diecut-cli/src/commands/search.rs
+++ b/crates/diecut-cli/src/commands/search.rs
@@ -1,0 +1,60 @@
+use console::style;
+use miette::Result;
+
+use diecut_core::registry::search_github;
+
+pub fn run(query: String) -> Result<()> {
+    println!(
+        "{} {}",
+        style("Searching templates for").bold(),
+        style(&query).cyan()
+    );
+    println!();
+
+    let entries = search_github(&query)?;
+
+    if entries.is_empty() {
+        println!(
+            "{}",
+            style("No templates found. Try a different search term.").yellow()
+        );
+        return Ok(());
+    }
+
+    for entry in &entries {
+        println!(
+            "{} by {}",
+            style(&entry.name).green().bold(),
+            style(&entry.author).cyan()
+        );
+        if !entry.description.is_empty() {
+            println!("  {}", entry.description);
+        }
+        if !entry.tags.is_empty() {
+            let tags: Vec<_> = entry
+                .tags
+                .iter()
+                .filter(|t| *t != "diecut-template")
+                .collect();
+            if !tags.is_empty() {
+                println!(
+                    "  Tags: {}",
+                    tags.iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+        }
+        println!("  Install: diecut new gh:{}/{}", entry.author, entry.name);
+        println!();
+    }
+
+    println!(
+        "{} Found {} template(s)",
+        style("✓").green().bold(),
+        entries.len()
+    );
+
+    Ok(())
+}

--- a/crates/diecut-cli/src/main.rs
+++ b/crates/diecut-cli/src/main.rs
@@ -16,6 +16,8 @@ fn main() -> miette::Result<()> {
         } => commands::new::run(template, output, data, defaults, overwrite, no_hooks),
         Commands::List => commands::list::run(),
         Commands::Check { path } => commands::check::run(path),
+        Commands::Search { query } => commands::search::run(query),
+        Commands::Publish { path } => commands::publish::run(path),
         Commands::Migrate {
             path,
             output,

--- a/crates/diecut-core/Cargo.toml
+++ b/crates/diecut-core/Cargo.toml
@@ -24,3 +24,4 @@ dirs = { workspace = true }
 gix = { workspace = true }
 tempfile = { workspace = true }
 sha2 = { workspace = true }
+ureq = { workspace = true }

--- a/crates/diecut-core/src/error.rs
+++ b/crates/diecut-core/src/error.rs
@@ -121,6 +121,16 @@ pub enum DicecutError {
     #[error("Git checkout failed for ref '{git_ref}'")]
     #[diagnostic(help("Ensure the branch, tag, or commit exists in the repository"))]
     GitCheckout { git_ref: String, reason: String },
+
+    #[error("Registry search failed: {message}")]
+    #[diagnostic(help("Check your network connection and try again"))]
+    RegistrySearchError { message: String },
+
+    #[error("GitHub API rate limit exceeded")]
+    #[diagnostic(help(
+        "GitHub allows 10 unauthenticated requests/minute. Wait a moment and try again."
+    ))]
+    RateLimited,
 }
 
 pub type Result<T> = std::result::Result<T, DicecutError>;

--- a/crates/diecut-core/src/lib.rs
+++ b/crates/diecut-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod error;
 pub mod hooks;
 pub mod prompt;
+pub mod registry;
 pub mod render;
 pub mod template;
 

--- a/crates/diecut-core/src/registry/mod.rs
+++ b/crates/diecut-core/src/registry/mod.rs
@@ -1,0 +1,3 @@
+mod search;
+
+pub use search::{search_github, RegistryEntry};

--- a/crates/diecut-core/src/registry/search.rs
+++ b/crates/diecut-core/src/registry/search.rs
@@ -1,0 +1,197 @@
+use serde::Deserialize;
+
+use crate::error::{DicecutError, Result};
+
+#[derive(Debug, Clone)]
+pub struct RegistryEntry {
+    pub name: String,
+    pub description: String,
+    pub source: String,
+    pub tags: Vec<String>,
+    pub author: String,
+    pub updated: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GithubSearchResponse {
+    items: Vec<GithubRepo>,
+}
+
+#[derive(Deserialize)]
+struct GithubRepo {
+    name: String,
+    description: Option<String>,
+    clone_url: String,
+    topics: Option<Vec<String>>,
+    owner: GithubOwner,
+    updated_at: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GithubOwner {
+    login: String,
+}
+
+pub fn parse_github_response(json: &str) -> Result<Vec<RegistryEntry>> {
+    let response: GithubSearchResponse =
+        serde_json::from_str(json).map_err(|e| DicecutError::RegistrySearchError {
+            message: format!("Failed to parse GitHub response: {e}"),
+        })?;
+
+    Ok(response
+        .items
+        .into_iter()
+        .map(|repo| RegistryEntry {
+            name: repo.name,
+            description: repo.description.unwrap_or_default(),
+            source: repo.clone_url,
+            tags: repo.topics.unwrap_or_default(),
+            author: repo.owner.login,
+            updated: repo.updated_at,
+        })
+        .collect())
+}
+
+pub fn search_github(query: &str) -> Result<Vec<RegistryEntry>> {
+    let url = format!(
+        "https://api.github.com/search/repositories?q={}+topic:diecut-template",
+        query
+    );
+
+    let response = ureq::get(&url)
+        .header("User-Agent", "diecut-cli")
+        .header("Accept", "application/vnd.github.v3+json")
+        .call()
+        .map_err(|e| {
+            if let ureq::Error::StatusCode(403) = &e {
+                return DicecutError::RateLimited;
+            }
+            if let ureq::Error::StatusCode(422) = &e {
+                return DicecutError::RegistrySearchError {
+                    message: "Invalid search query".to_string(),
+                };
+            }
+            DicecutError::RegistrySearchError {
+                message: format!("HTTP request failed: {e}"),
+            }
+        })?;
+
+    let body =
+        response
+            .into_body()
+            .read_to_string()
+            .map_err(|e| DicecutError::RegistrySearchError {
+                message: format!("Failed to read response body: {e}"),
+            })?;
+
+    parse_github_response(&body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MOCK_GITHUB_RESPONSE: &str = r#"{
+        "total_count": 2,
+        "incomplete_results": false,
+        "items": [
+            {
+                "name": "rust-cli-template",
+                "full_name": "alice/rust-cli-template",
+                "description": "Production-ready Rust CLI template",
+                "clone_url": "https://github.com/alice/rust-cli-template.git",
+                "topics": ["rust", "cli", "diecut-template"],
+                "owner": { "login": "alice" },
+                "updated_at": "2026-01-15T10:30:00Z"
+            },
+            {
+                "name": "python-api",
+                "full_name": "bob/python-api",
+                "description": "FastAPI template with Docker",
+                "clone_url": "https://github.com/bob/python-api.git",
+                "topics": ["python", "api", "docker", "diecut-template"],
+                "owner": { "login": "bob" },
+                "updated_at": "2026-02-01T08:00:00Z"
+            }
+        ]
+    }"#;
+
+    const MOCK_EMPTY_RESPONSE: &str = r#"{
+        "total_count": 0,
+        "incomplete_results": false,
+        "items": []
+    }"#;
+
+    const MOCK_MINIMAL_RESPONSE: &str = r#"{
+        "total_count": 1,
+        "incomplete_results": false,
+        "items": [
+            {
+                "name": "bare-template",
+                "full_name": "user/bare-template",
+                "description": null,
+                "clone_url": "https://github.com/user/bare-template.git",
+                "topics": null,
+                "owner": { "login": "user" },
+                "updated_at": null
+            }
+        ]
+    }"#;
+
+    #[test]
+    fn test_parse_github_response_with_results() {
+        let entries = parse_github_response(MOCK_GITHUB_RESPONSE).unwrap();
+        assert_eq!(entries.len(), 2);
+
+        assert_eq!(entries[0].name, "rust-cli-template");
+        assert_eq!(entries[0].author, "alice");
+        assert_eq!(entries[0].description, "Production-ready Rust CLI template");
+        assert_eq!(
+            entries[0].source,
+            "https://github.com/alice/rust-cli-template.git"
+        );
+        assert_eq!(entries[0].tags, vec!["rust", "cli", "diecut-template"]);
+        assert_eq!(entries[0].updated, Some("2026-01-15T10:30:00Z".to_string()));
+
+        assert_eq!(entries[1].name, "python-api");
+        assert_eq!(entries[1].author, "bob");
+        assert_eq!(entries[1].tags.len(), 4);
+    }
+
+    #[test]
+    fn test_parse_github_response_empty() {
+        let entries = parse_github_response(MOCK_EMPTY_RESPONSE).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_parse_github_response_minimal_fields() {
+        let entries = parse_github_response(MOCK_MINIMAL_RESPONSE).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "bare-template");
+        assert_eq!(entries[0].description, "");
+        assert!(entries[0].tags.is_empty());
+        assert!(entries[0].updated.is_none());
+    }
+
+    #[test]
+    fn test_parse_github_response_invalid_json() {
+        let result = parse_github_response("not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_registry_entry_fields() {
+        let entry = RegistryEntry {
+            name: "my-template".to_string(),
+            description: "A test template".to_string(),
+            source: "https://github.com/user/my-template.git".to_string(),
+            tags: vec!["rust".to_string(), "cli".to_string()],
+            author: "user".to_string(),
+            updated: Some("2026-01-01T00:00:00Z".to_string()),
+        };
+        assert_eq!(entry.name, "my-template");
+        assert_eq!(entry.author, "user");
+        assert_eq!(entry.tags.len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds template registry module using GitHub topic-based discovery (no central server, like Go modules)
- Adds `diecut search <query>` command that searches GitHub repos with the `diecut-template` topic
- Adds `diecut publish [path]` command that validates a template and prints publishing instructions
- Uses `ureq` for lightweight blocking HTTP to the GitHub Search API
- Includes 5 unit tests for JSON response parsing (mock data, no real HTTP calls)

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 95 tests pass (75 unit + 20 integration)
- [ ] Manual: `diecut search rust` returns results from GitHub
- [ ] Manual: `diecut publish .` in a valid template dir shows success and instructions
- [ ] Manual: `diecut publish .` in an invalid dir shows validation errors