### PR TITLE
fix: add file-based cache lock with stale detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,7 @@ version = "0.1.0"
 dependencies = [
  "console",
  "dirs",
+ "filetime",
  "gix",
  "globset",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ tempfile = "3"
 gix = { version = "0.72", default-features = false, features = ["blocking-network-client", "blocking-http-transport-reqwest-rust-tls", "worktree-mutation"] }
 sha2 = "0.10"
 similar = "2"
+filetime = "0.2"

--- a/crates/diecut-core/Cargo.toml
+++ b/crates/diecut-core/Cargo.toml
@@ -25,3 +25,6 @@ gix = { workspace = true }
 tempfile = { workspace = true }
 sha2 = { workspace = true }
 similar = { workspace = true }
+
+[dev-dependencies]
+filetime = { workspace = true }


### PR DESCRIPTION
## Summary
- Adds a file-based lock to `get_or_clone()` preventing concurrent processes from racing to clone the same template
- Stale locks (>10 minutes) are detected via modification time and broken automatically, preventing permanent blockage from crashed processes
- Lock guard uses RAII pattern — lock is released on drop, even on error paths

## Test plan
- [x] New unit tests for lock acquisition, stale detection, PID content, and drop cleanup
- [x] Existing cache tests pass unchanged
- [x] Full test suite green