### PR TITLE
fix: include file path in template render error messages

### DIFF
--- a/crates/diecut-core/src/error.rs
+++ b/crates/diecut-core/src/error.rs
@@ -24,9 +24,10 @@ pub enum DicecutError {
     #[error("Validation failed for variable '{name}': {message}")]
     ValidationFailed { name: String, message: String },
 
-    #[error("Template rendering failed")]
+    #[error("Template rendering failed for '{file}'")]
     #[diagnostic(help("Check your Tera template syntax"))]
     RenderError {
+        file: String,
         #[source]
         source: tera::Error,
     },

--- a/crates/diecut-core/src/render/file.rs
+++ b/crates/diecut-core/src/render/file.rs
@@ -6,7 +6,10 @@ use crate::error::{DicecutError, Result};
 
 pub fn render_file_content(tera: &Tera, template_name: &str, context: &Context) -> Result<String> {
     tera.render(template_name, context)
-        .map_err(|e| DicecutError::RenderError { source: e })
+        .map_err(|e| DicecutError::RenderError {
+            file: template_name.to_string(),
+            source: e,
+        })
 }
 
 /// Render template expressions in a path component (e.g. `{{project_name}}`).

--- a/crates/diecut-core/src/render/walker.rs
+++ b/crates/diecut-core/src/render/walker.rs
@@ -124,7 +124,10 @@ pub fn walk_and_render(
                     files_copied.push(rendered_rel);
                 }
                 Err(e) => {
-                    return Err(DicecutError::RenderError { source: e });
+                    return Err(DicecutError::RenderError {
+                        file: rel_str.to_string(),
+                        source: e,
+                    });
                 }
             }
         }
@@ -198,7 +201,10 @@ fn evaluate_when_expr(when_expr: &str, variables: &BTreeMap<String, Value>) -> R
     let mut tera = Tera::default();
     let template_str = format!("{{% if {when_expr} %}}true{{% else %}}false{{% endif %}}");
     tera.add_raw_template("__when__", &template_str)
-        .map_err(|e| DicecutError::RenderError { source: e })?;
+        .map_err(|e| DicecutError::RenderError {
+            file: format!("(when expression: {when_expr})"),
+            source: e,
+        })?;
 
     let mut context = Context::new();
     for (k, v) in variables {
@@ -207,7 +213,10 @@ fn evaluate_when_expr(when_expr: &str, variables: &BTreeMap<String, Value>) -> R
 
     let result = tera
         .render("__when__", &context)
-        .map_err(|e| DicecutError::RenderError { source: e })?;
+        .map_err(|e| DicecutError::RenderError {
+            file: format!("(when expression: {when_expr})"),
+            source: e,
+        })?;
 
     Ok(result.trim() == "true")
 }


### PR DESCRIPTION
## Summary
- `RenderError` now includes a `file` field identifying which template file caused the rendering failure
- Conditional `when` expression errors now include the expression text in the error message
- Makes debugging template syntax errors in larger projects significantly easier

## Test plan
- [x] All existing tests pass (error variant updated at all 4 call sites)
- [x] `cargo clippy -- -D warnings` clean