### PR TITLE
chore: remove unused indicatif dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,6 @@ dependencies = [
  "dirs",
  "gix",
  "globset",
- "indicatif",
  "inquire",
  "miette",
  "regex-lite",
@@ -1861,19 +1860,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console",
- "number_prefix",
- "portable-atomic",
- "unicode-width 0.2.2",
- "web-time",
-]
-
-[[package]]
 name = "inquire"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,12 +2163,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ regex-lite = "0.1"
 thiserror = "2"
 miette = { version = "7", features = ["fancy"] }
 walkdir = "2"
-indicatif = "0.17"
 console = "0.15"
 dirs = "6"
 rhai = { version = "1", features = ["sync"] }

--- a/crates/diecut-core/Cargo.toml
+++ b/crates/diecut-core/Cargo.toml
@@ -17,7 +17,6 @@ thiserror = { workspace = true }
 miette = { workspace = true }
 walkdir = { workspace = true }
 inquire = { workspace = true }
-indicatif = { workspace = true }
 console = { workspace = true }
 rhai = { workspace = true }
 dirs = { workspace = true }


### PR DESCRIPTION
## Summary
- Removed `indicatif` from workspace `Cargo.toml` and `crates/diecut-core/Cargo.toml`
- The dependency was declared but never imported or used in any source file

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All 104 tests pass