### PR TITLE
fix: add cargo-workspace plugin to release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "plugins": ["cargo-workspace"],
   "packages": {
     ".": {
       "release-type": "rust",


### PR DESCRIPTION
## Summary

- Adds `"plugins": ["cargo-workspace"]` to `release-please-config.json`
- Fixes the `value at path package.version is not tagged` error caused by `version.workspace = true` inheritance

## Context

The release-please workflow added in c752cd6 fails because both crates use `version.workspace = true` and release-please doesn't understand workspace version inheritance without the `cargo-workspace` plugin enabled.

## Test plan

- [x] Merge and verify the release-please workflow passes on main