### PR TITLE
fix: use explicit versions in subcrate Cargo.toml for release-please

### DIFF
--- a/crates/diecut-cli/Cargo.toml
+++ b/crates/diecut-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diecut"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/diecut-core/Cargo.toml
+++ b/crates/diecut-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diecut-core"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary
- Replace `version.workspace = true` with explicit `version = "0.1.0"` in both subcrate Cargo.toml files
- Fixes the release-please `cargo-workspace` plugin failing with "invalid [package.version]" because it cannot parse workspace-inherited versions as semver strings

## Context
The `release-please` job on main has been failing: https://github.com/raiderrobert/diecut/actions/runs/21999020637/job/63566538232

The `cargo-workspace` plugin needs to read explicit version strings from each member crate's `Cargo.toml`. The `version.workspace = true` syntax (Cargo workspace inheritance) is not supported by the plugin.

Other `[workspace.package]` fields (`edition`, `license`, `rust-version`) are left as workspace-inherited since release-please doesn't need to parse or update those.