### PR TITLE
fix: remove cargo-workspace plugin and restore version.workspace

### DIFF
--- a/crates/diecut-cli/Cargo.toml
+++ b/crates/diecut-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diecut"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/diecut-core/Cargo.toml
+++ b/crates/diecut-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diecut-core"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "plugins": ["cargo-workspace"],
   "packages": {
     ".": {
       "release-type": "rust",


### PR DESCRIPTION
## Summary
- Remove the `cargo-workspace` plugin from `release-please-config.json` — it crashes on workspace-only root manifests ([googleapis/release-please#2356](https://github.com/googleapis/release-please/issues/2356))
- Restore `version.workspace = true` in subcrate Cargo.toml files (reverts the explicit versions from PR #34)

## Why this works
The `cargo-workspace` plugin is unnecessary for this project. The base Rust strategy at `"."` reads `[workspace.package].version` from the root `Cargo.toml` and bumps it in release PRs. Both subcrates inherit the version via `version.workspace = true`, so they stay in sync automatically — no plugin needed.

## What was failing
1. **PR #34 fix**: The plugin couldn't parse `version.workspace = true` as a semver string → "invalid [package.version]"
2. **After PR #34**: With explicit versions, the plugin could read versions but then crashed with `Cannot read properties of undefined (reading 'pullRequest')` because the workspace root has no `[package.name]`
3. **This PR**: Removes the plugin entirely, avoiding both bugs