### PR TITLE
fix: configure release-please for Rust workspace per upstream pattern

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,4 @@
-{".":"0.1.0"}
+{
+  "crates/diecut-cli": "0.1.0",
+  "crates/diecut-core": "0.1.0"
+}

--- a/crates/diecut-cli/Cargo.toml
+++ b/crates/diecut-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diecut"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/diecut-core/Cargo.toml
+++ b/crates/diecut-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diecut-core"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,17 +1,19 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "rust",
+  "bump-minor-pre-major": false,
+  "bump-patch-for-minor-pre-major": true,
+  "bootstrap-sha": "6a264718a3e9bd18802c16dc85504457d2bbfc90",
+  "plugins": ["cargo-workspace"],
   "packages": {
-    ".": {
-      "release-type": "rust",
-      "bump-minor-pre-major": false,
-      "bump-patch-for-minor-pre-major": true,
-      "changelog-sections": [
-        { "type": "feat", "section": "Features" },
-        { "type": "fix", "section": "Bug Fixes" },
-        { "type": "chore", "section": "Miscellaneous" },
-        { "type": "docs", "section": "Documentation" },
-        { "type": "refactor", "section": "Code Refactoring" }
-      ]
-    }
-  }
+    "crates/diecut-cli": {},
+    "crates/diecut-core": {}
+  },
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "chore", "section": "Miscellaneous" },
+    { "type": "docs", "section": "Documentation" },
+    { "type": "refactor", "section": "Code Refactoring" }
+  ]
 }


### PR DESCRIPTION
## Summary
- List each subcrate as a separate package in release-please config (not `"."`)
- Use explicit `version = "0.1.0"` in subcrate Cargo.toml files (cargo-workspace plugin can't parse `version.workspace = true`)
- Add `bootstrap-sha` pointing to the v0.1.0 release commit
- Move shared config (release-type, changelog-sections) to top level

## Why
The previous config used `"."` as the package path, pointing at a workspace-only root `Cargo.toml` (no `[package]` section). This doesn't work because:
1. The cargo-workspace plugin can't parse `version.workspace = true` as semver
2. Without the plugin, the Rust strategy also rejects non-string version fields
3. With explicit versions but `"."` as the path, the plugin crashes on the workspace root having no `[package.name]`

The correct pattern (used by [AccessKit](https://github.com/AccessKit/accesskit), [aliri](https://github.com/neoeinstein/aliri), [state-machines-rs](https://github.com/state-machines/state-machines-rs)) is to list each subcrate path separately in `packages` with explicit version strings.

## Note on tag format
With multiple packages, release-please will use component-prefixed tags going forward (e.g. `diecut-v0.1.1`, `diecut-core-v0.1.1`) instead of the previous bare `v0.1.0`. The `bootstrap-sha` config ensures release-please knows where to start the commit history for the new tag format.