### PR TITLE
fix: remove component prefix from release-please tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "rust",
+      "include-component-in-tag": false,
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
## Summary

- Adds `include-component-in-tag: false` to release-please config
- Fixes release build workflow never triggering because tags were `diecut-v0.1.1` instead of `v0.1.1`
- The existing `diecut-v0.1.1` release will need its assets populated manually or via a new release

## Test plan

- [x] Verify JSON is valid
- [x] Next release-please PR should create a `v*` tag, triggering the release build workflow