### PR TITLE
fix: update stale crate paths after single-crate merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - "crates/**"
+      - "src/**"
       - "examples/**"
       - "Cargo.toml"
       - "Cargo.lock"
@@ -13,7 +13,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - "crates/**"
+      - "src/**"
       - "examples/**"
       - "Cargo.toml"
       - "Cargo.lock"

--- a/justfile
+++ b/justfile
@@ -30,4 +30,4 @@ docs-build:
 
 # Install diecut locally
 install:
-    cargo install --path crates/diecut-cli
+    cargo install --path .


### PR DESCRIPTION
## Summary
- CI path filter watched `crates/**` which no longer exists after the single-crate refactor — changed to `src/**`
- Fixed justfile `install` recipe to use `cargo install --path .` instead of the old `crates/diecut-cli` path