### PR TITLE
docs: add CONTRIBUTING.md and fix stale paths in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to diecut
+
+## Prerequisites
+
+- [Rust](https://rustup.rs/) (stable)
+- [just](https://github.com/casey/just) task runner
+
+## Development
+
+All tasks are managed through the justfile. Run `just` to see available recipes:
+
+```bash
+just          # list all recipes
+just check    # run fmt, clippy, and tests
+just test     # run tests (supports extra args: just test -- --nocapture)
+just build    # build release binary
+just fmt      # auto-format code
+just install  # install diecut locally
+```
+
+## Before Submitting a PR
+
+Run the full check suite:
+
+```bash
+just check
+```
+
+This runs `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test`.
+
+## Docs Site
+
+The documentation site lives in `docs/` and uses pnpm:
+
+```bash
+just docs       # start dev server
+just docs-build # build site
+```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ curl -fsSL https://raw.githubusercontent.com/raiderrobert/diecut/main/install.sh
 Or build from source:
 
 ```bash
-cargo install --path crates/diecut-cli
+cargo install --path .
 ```
 
 Or grab a binary from [GitHub Releases](https://github.com/raiderrobert/diecut/releases).
@@ -40,13 +40,9 @@ Full documentation: **[diecut docs](https://diecut.dev/)**
 - [diecut.toml Reference](https://diecut.dev/diecut/reference/diecut-toml/) — complete config file reference
 - [Hooks Reference](https://diecut.dev/diecut/reference/hooks/) — Rhai scripting for templates
 
-## Development
+## Contributing
 
-```bash
-cargo test
-cargo fmt --check
-cargo clippy -- -D warnings
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and workflow.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Move development instructions from README into a new CONTRIBUTING.md that references the justfile as the canonical task runner
- Fix stale `cargo install --path crates/diecut-cli` in README → `cargo install --path .`
- Replace inline dev commands in README with a link to CONTRIBUTING.md