### PR TITLE
fix: release binaries not building for v0.1.1+

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release-please
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Dispatch release build
+        if: ${{ steps.release-please.outputs.releases_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run release.yml -f tag=${{ steps.release-please.outputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,12 @@
 name: Release
 
 on:
-  push:
-    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to build and release (e.g. v0.1.2)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -23,6 +27,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -54,10 +60,10 @@ jobs:
         with:
           merge-multiple: true
 
-      - name: Create GitHub Release
+      - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          tag_name: ${{ inputs.tag }}
           files: |
             diecut-x86_64-linux.tar.gz
             diecut-aarch64-macos.tar.gz

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ main() {
         echo "  - macOS (Apple Silicon / aarch64)" >&2
         echo "  - Linux (x86_64)" >&2
         echo "" >&2
-        echo "You can build from source instead: cargo install --path crates/diecut-cli" >&2
+        echo "You can build from source instead: cargo install --path ." >&2
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

- **release-please.yml**: After creating a release, dispatch `release.yml` via `gh workflow run` with the tag name — workaround for GitHub's security feature where `GITHUB_TOKEN`-created tags don't trigger other workflows
- **release.yml**: Switch from `push: tags` to `workflow_dispatch` with a `tag` input; checkout the tagged commit and attach binaries to the existing release
- **install.sh**: Fix stale `cargo install --path crates/diecut-cli` to `cargo install --path .` after the single-crate merge

## Test plan

- [ ] Verify workflows pass YAML lint / Actions validation
- [ ] On next release-please merge, confirm release.yml is dispatched and binaries are attached
- [ ] Test `curl -fsSL .../install.sh | sh` downloads the correct binary