### PR TITLE
fix: release binaries not building for v0.1.1+

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
       - main
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
## Summary

- **release-please.yml**: After creating a release, dispatch `release.yml` via `gh workflow run` with the tag name — workaround for GitHub's security feature where `GITHUB_TOKEN`-created tags don't trigger other workflows
- **release.yml**: Switch from `push: tags` to `workflow_dispatch` with a `tag` input; checkout the tagged commit and attach binaries to the existing release
- **install.sh**: Fix stale `cargo install --path crates/diecut-cli` to `cargo install --path .` after the single-crate merge

## Test plan

- [ ] Verify workflows pass YAML lint / Actions validation
- [ ] On next release-please merge, confirm release.yml is dispatched and binaries are attached
- [ ] Test `curl -fsSL .../install.sh | sh` downloads the correct binary