### PR TITLE
fix: suppress interactive git credential prompts

### DIFF
--- a/src/template/clone.rs
+++ b/src/template/clone.rs
@@ -57,7 +57,10 @@ pub fn clone_template(url: &str, git_ref: Option<&str>) -> Result<CloneResult> {
     })?;
 
     let mut cmd = Command::new("git");
-    cmd.arg("clone").arg("--depth").arg("1");
+    cmd.env("GIT_TERMINAL_PROMPT", "0")
+        .arg("clone")
+        .arg("--depth")
+        .arg("1");
 
     if let Some(ref_name) = git_ref {
         cmd.arg("--branch").arg(ref_name);
@@ -176,6 +179,14 @@ mod tests {
         let msg =
             classify_clone_error("fatal: unable to access: Could not resolve host: github.com");
         assert!(msg.contains("network error"));
+    }
+
+    #[test]
+    fn classify_terminal_prompts_disabled() {
+        let msg = classify_clone_error(
+            "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+        );
+        assert!(msg.contains("configure git credentials"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Set `GIT_TERMINAL_PROMPT=0` on git clone to prevent interactive credential prompts that hang the CLI when credentials aren't cached or the repo doesn't exist
- Credential helpers (macOS Keychain, `gh auth`, SSH agent) still work automatically since they don't require terminal interaction
- Added test for the "terminal prompts disabled" error classification path

## Context

When running `diecut new gh:user/repo` against a private repo or non-existent repo (GitHub returns 401 to prevent enumeration), system git prompts interactively for a username, hanging the CLI. This is the same issue Go solved in v1.5 by setting `GIT_TERMINAL_PROMPT=0` by default.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes  
- [x] `cargo test` passes (91 unit + 30 integration)
- [ ] Manual: `diecut new gh:nonexistent/repo` fails cleanly with "configure git credentials" message instead of prompting