### PR TITLE
refactor: split generate() into plan and execute phases

### DIFF
--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3,4 +3,6 @@ pub mod file;
 pub mod walker;
 
 pub use context::{build_context, build_context_with_namespace};
-pub use walker::{walk_and_render, GeneratedProject};
+pub use walker::{
+    execute_plan, plan_render, walk_and_render, GeneratedProject, GenerationPlan, PlannedFile,
+};


### PR DESCRIPTION
## Summary

- Factor `walk_and_render()` into `plan_render()` + `execute_plan()` — renders all files in memory first, then writes to disk as a separate step
- Factor `generate()` into `plan_generation()` + `execute_generation()` — aligns `new` command architecture with `update`'s existing `three_way_merge()` → `apply_merge()` pattern
- No behavior change — all 30 existing tests pass unmodified, 3 new tests added

## Motivation

Enables dry-run support for the `new` command (see #62) by separating what-would-happen from actually-doing-it. This is a prerequisite refactor.

## Test plan

- [x] `cargo test` — all 33 tests pass (30 existing + 3 new)
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] New `test_plan_render_matches_walk_and_render` verifies byte-for-byte identical output
- [x] New `test_plan_render_file_counts` verifies correct rendered/copied counts
- [x] New `test_plan_render_conditional_exclude` verifies conditional file exclusion in plan phase

Closes #61
Blocks #62