### PR TITLE
feat: add --dry-run flag to new command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,6 +37,10 @@ pub enum Commands {
         /// Skip running hooks
         #[arg(long)]
         no_hooks: bool,
+
+        /// Show what would be generated without writing files
+        #[arg(long)]
+        dry_run: bool,
     },
 
     /// List cached templates

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,10 @@ fn main() -> miette::Result<()> {
             defaults,
             overwrite,
             no_hooks,
-        } => commands::new::run(template, output, data, defaults, overwrite, no_hooks),
+            dry_run,
+        } => commands::new::run(
+            template, output, data, defaults, overwrite, no_hooks, dry_run,
+        ),
         Commands::List => commands::list::run(),
         Commands::Update {
             path,


### PR DESCRIPTION
## Summary

- Add `--dry-run` flag to `diecut new` that previews generated files without writing to disk
- Calls `plan_generation()` (from #64) to render templates in memory, then displays file list and summary
- When not dry-run, behavior is unchanged

## Example output

```
==> Dry run — files that would be generated in my-project/:

  create README.md
  create src/main.rs
  create Cargo.toml
  copy   logo.png

Summary: 3 rendered, 1 copied

ℹ Dry run — no files written.
```

## Dependencies

Depends on #64 (refactor: split generate() into plan and execute phases)

## Test plan

- [x] `cargo test` — all 34 tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] New `test_plan_generation_dry_run_no_files_written` verifies plan has files but output directory does not exist

Closes #62