### PR TITLE
feat: add --dry-run flag to update command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -51,6 +51,10 @@ pub enum Commands {
         /// Git ref (branch, tag, commit) to update the template to
         #[arg(long = "ref")]
         git_ref: Option<String>,
+
+        /// Show what would change without modifying files
+        #[arg(long)]
+        dry_run: bool,
     },
 
     /// Validate a template directory

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,11 @@ fn main() -> miette::Result<()> {
             no_hooks,
         } => commands::new::run(template, output, data, defaults, overwrite, no_hooks),
         Commands::List => commands::list::run(),
-        Commands::Update { path, git_ref } => commands::update::run(path, git_ref),
+        Commands::Update {
+            path,
+            git_ref,
+            dry_run,
+        } => commands::update::run(path, git_ref, dry_run),
         Commands::Check { path } => commands::check::run(path),
         Commands::Ready { path } => commands::ready::run(path),
         Commands::Migrate {

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -16,6 +16,7 @@ use merge::{three_way_merge, FileMergeResult, MergeAction};
 pub struct UpdateOptions {
     pub template_source: Option<String>,
     pub git_ref: Option<String>,
+    pub dry_run: bool,
 }
 
 pub struct UpdateReport {
@@ -143,6 +144,10 @@ pub fn update_project(project_path: &Path, options: UpdateOptions) -> Result<Upd
     let merge_results = three_way_merge(project_path, old_snapshot.path(), new_snapshot.path())?;
 
     let report = UpdateReport::from_results(&merge_results);
+
+    if options.dry_run {
+        return Ok(report);
+    }
 
     merge::apply_merge(
         project_path,


### PR DESCRIPTION
## Summary

- Add `--dry-run` flag to `diecut update` that shows what would change without modifying files
- Skips `apply_merge()` and `write_answers_with_source()` when dry-run is set
- Reuses existing `three_way_merge()` plan — the architecture already separated planning from execution

## Example output

```
... Updating project at /path/to/project

Would update: 1 updated, 1 added, 1 marked for removal, 1 conflicts

  ↻ Updated:
    src/lib.rs

  + Added:
    tests/new_test.rs

  - Marked for removal (review manually):
    old_file.rs

  ! Conflicts (see .rej files):
    src/config.rs

ℹ Dry run — no changes written.
```

## Test plan

- [x] `cargo test` — all 31 tests pass
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] New `test_update_dry_run_no_changes_written` verifies merge plan is computed but no files are modified, no `.rej` or `.removing` files created

Closes #60