### PR TITLE
fix: docs cleanup — linked cards, README 404, simplify templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,12 @@ diecut new ./my-template --output my-project
 diecut list
 ```
 
-### Available starter templates
+### Starter templates
 
-See [diecut-templates](https://github.com/raiderrobert/diecut-templates) for the full list.
+[diecut-templates](https://github.com/raiderrobert/diecut-templates) has ready-to-use templates:
 
 ```bash
-diecut new gh:raiderrobert/diecut-templates/python-pkg   # Python package (src layout, hatchling)
-diecut new gh:raiderrobert/diecut-templates/rust-cli      # Rust CLI application
-diecut new gh:raiderrobert/diecut-templates/static-site   # Static HTML site
+diecut new gh:raiderrobert/diecut-templates/python-pkg --output my-project
 ```
 
 ## Documentation
@@ -50,7 +48,7 @@ Full documentation: **[diecut docs](https://diecut.dev/)**
 - [Using Templates](https://diecut.dev/using-templates/) — sources, overrides, abbreviations
 - [Creating Templates](https://diecut.dev/creating-templates/) — build your own templates
 - [Commands Reference](https://diecut.dev/reference/commands/) — all CLI commands and options
-- [diecut.toml Reference](https://diecut.dev/diecut/reference/diecut-toml/) — complete config file reference
+- [diecut.toml Reference](https://diecut.dev/reference/diecut-toml/) — complete config file reference
 
 ## Contributing
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -15,21 +15,13 @@ hero:
       variant: minimal
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid>
-	<Card title="Single binary" icon="rocket">
-		No Python, no Node, no runtime dependencies. Download one file and go.
-	</Card>
-	<Card title="Easy to make" icon="pencil">
-		A diecut.toml and a folder — that's a template. You just made one.
-	</Card>
-	<Card title="Multi-template repos" icon="puzzle">
-		One repo, many templates. Use subpaths to pick the one you want.
-	</Card>
-	<Card title="Any Git host" icon="external">
-		GitHub, GitLab, Bitbucket, Sourcehut — or any Git URL.
-	</Card>
+	<LinkCard title="Single binary" description="No Python, no Node, no runtime dependencies. Download one file and go." href="/getting-started/" />
+	<LinkCard title="Easy to make" description="A diecut.toml and a folder — that's a template. You just made one." href="/creating-templates/" />
+	<LinkCard title="Multi-template repos" description="One repo, many templates. Use subpaths to pick the one you want." href="/using-templates/" />
+	<LinkCard title="Any Git host" description="GitHub, GitLab, Bitbucket, Sourcehut — or any Git URL." href="/using-templates/" />
 </CardGrid>
 
 ## Why diecut?


### PR DESCRIPTION
## Summary
- Landing page cards now use `LinkCard` with `href` links to relevant docs pages
- Fix 404 on README diecut.toml reference link (extra `/diecut/` path segment)
- Simplify starter templates section to one example instead of three with inline comments

## Test plan
- [x] Docs site builds successfully (`pnpm build` — 8 pages, no errors)
- [x] LinkCards render with clickable links to correct pages
- [x] README diecut.toml link resolves to `/reference/diecut-toml/`