### PR TITLE
chore: remove Sourcehut (sr:) abbreviation

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -21,7 +21,7 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 	<LinkCard title="Single binary" description="No Python, no Node, no runtime dependencies. Download one file and go." href="/getting-started/" />
 	<LinkCard title="Easy to make" description="A diecut.toml and a folder — that's a template. You just made one." href="/creating-templates/" />
 	<LinkCard title="Multi-template repos" description="One repo, many templates. Use subpaths to pick the one you want." href="/using-templates/" />
-	<LinkCard title="Any Git host" description="GitHub, GitLab, Bitbucket, Sourcehut — or any Git URL." href="/using-templates/" />
+	<LinkCard title="Any Git host" description="GitHub, GitLab, Bitbucket — or any Git URL." href="/using-templates/" />
 </CardGrid>
 
 ## Why diecut?

--- a/docs/src/content/docs/reference/commands.md
+++ b/docs/src/content/docs/reference/commands.md
@@ -17,7 +17,7 @@ diecut new <TEMPLATE> [OPTIONS]
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `<TEMPLATE>` | — | Template source: local path, `gh:user/repo`, `gl:user/repo`, `bb:user/repo`, `sr:user/repo`, any Git URL, or abbreviation with subpath (`gh:user/repo/subdir`) |
+| `<TEMPLATE>` | — | Template source: local path, `gh:user/repo`, `gl:user/repo`, `bb:user/repo`, any Git URL, or abbreviation with subpath (`gh:user/repo/subdir`) |
 | `-o, --output <PATH>` | — | Output directory |
 | `-d, --data <KEY=VALUE>` | — | Override variable values (repeatable) |
 | `--defaults` | `false` | Use default values without prompting |

--- a/docs/src/content/docs/using-templates/index.mdx
+++ b/docs/src/content/docs/using-templates/index.mdx
@@ -13,7 +13,6 @@ diecut pulls templates from local paths or any Git host.
 | GitHub | `diecut new gh:user/repo` |
 | GitLab | `diecut new gl:user/repo` |
 | Bitbucket | `diecut new bb:user/repo` |
-| Sourcehut | `diecut new sr:user/repo` |
 | Any Git URL | `diecut new https://git.example.com/repo.git` |
 
 Git templates are cached at `~/.cache/diecut/templates/`. Override with `DIECUT_CACHE_DIR`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,9 +79,7 @@ pub enum DicecutError {
     },
 
     #[error("Invalid template abbreviation: {input}")]
-    #[diagnostic(help(
-        "Supported abbreviations: gh:user/repo, gl:user/repo, bb:user/repo, sr:~user/repo"
-    ))]
+    #[diagnostic(help("Supported abbreviations: gh:user/repo, gl:user/repo, bb:user/repo"))]
     InvalidAbbreviation { input: String },
 
     #[error("Hook '{hook}' failed: {message}")]

--- a/src/template/source.rs
+++ b/src/template/source.rs
@@ -20,7 +20,6 @@ const ABBREVIATIONS: &[(&str, &str, &str)] = &[
     ("gh:", "https://github.com/", ".git"),
     ("gl:", "https://gitlab.com/", ".git"),
     ("bb:", "https://bitbucket.org/", ".git"),
-    ("sr:", "https://git.sr.ht/", ""),
 ];
 
 fn detect_github_protocol() -> String {
@@ -244,7 +243,6 @@ mod tests {
     #[rstest]
     #[case("gl:org/project", "https://gitlab.com/org/project.git")]
     #[case("bb:team/repo", "https://bitbucket.org/team/repo.git")]
-    #[case("sr:~user/repo", "https://git.sr.ht/~user/repo")]
     fn expand_abbreviation_cases(#[case] input: &str, #[case] expected_url: &str) {
         let expanded = expand_abbreviation(input).unwrap();
         assert_eq!(expanded.url, expected_url);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -287,7 +287,6 @@ fn test_resolve_source_rejects_empty_abbreviation_remainder() {
     assert!(resolve_source("gh:").is_err());
     assert!(resolve_source("gl:").is_err());
     assert!(resolve_source("bb:").is_err());
-    assert!(resolve_source("sr:").is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Remove `sr:` abbreviation for Sourcehut from source, tests, and docs
- Sourcehut has minimal adoption; simplifies the abbreviation set

## Changes
- Remove `sr:` from `ABBREVIATIONS` array and error hint
- Remove Sourcehut test case and integration test assertion
- Remove Sourcehut from docs (commands ref, using-templates table, landing page card)

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — 78 unit + 19 integration tests pass