### PR TITLE
feat: serve install script from diecut.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/raiderrobert/diecut/main/install.sh | sh
+curl -fsSL https://diecut.dev/install.sh | sh
 ```
 
 Or build from source:

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .astro/
+public/install.sh

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "prebuild": "cp ../install.sh public/install.sh",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"

--- a/docs/src/content/docs/getting-started/index.mdx
+++ b/docs/src/content/docs/getting-started/index.mdx
@@ -10,7 +10,7 @@ import { LinkCard } from '@astrojs/starlight/components';
 The quickest way:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/raiderrobert/diecut/main/install.sh | sh
+curl -fsSL https://diecut.dev/install.sh | sh
 ```
 
 Auto-detects your OS and architecture. Set `DIECUT_INSTALL_DIR` to change the install location.

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Diecut installer — https://github.com/raiderrobert/diecut
-# Usage: curl -fsSL https://raw.githubusercontent.com/raiderrobert/diecut/main/install.sh | sh
+# Usage: curl -fsSL https://diecut.dev/install.sh | sh
 set -e
 
 REPO="raiderrobert/diecut"


### PR DESCRIPTION
## Summary
- Add `prebuild` step in docs to copy `install.sh` into `public/` so it's served at `diecut.dev/install.sh`
- Update install URL in README, docs, and install script comment
- Gitignore the copied build artifact

Install command becomes:
```bash
curl -fsSL https://diecut.dev/install.sh | sh
```