### PR TITLE
fix: preserve variable prompt order from diecut.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,7 @@ dependencies = [
  "dirs",
  "fs4",
  "globset",
+ "indexmap",
  "inquire",
  "miette",
  "regex-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tempfile = "3"
 sha2 = "0.10"
 fs4 = "0.12"
 content_inspector = "0.2"
+indexmap = { version = "2.11.4", features = ["serde"] }
 
 [dev-dependencies]
 rstest = "0.23"

--- a/src/answers/mod.rs
+++ b/src/answers/mod.rs
@@ -183,6 +183,8 @@ fn tera_value_to_toml(value: &Value) -> Option<toml::Value> {
 
 #[cfg(test)]
 mod tests {
+    use indexmap::IndexMap;
+
     use super::*;
     use std::fs;
 
@@ -199,7 +201,7 @@ mod tests {
                 min_diecut_version: None,
                 templates_suffix: ".tera".to_string(),
             },
-            variables: BTreeMap::new(),
+            variables: IndexMap::new(),
             files: crate::config::schema::FilesConfig::default(),
             hooks: crate::config::schema::HooksConfig { post_create: None },
             answers: crate::config::schema::AnswersConfig::default(),
@@ -257,7 +259,7 @@ mod tests {
     fn test_write_answers_excludes_secret_variables() {
         let output_dir = tempfile::tempdir().unwrap();
 
-        let mut variables_config = BTreeMap::new();
+        let mut variables_config = IndexMap::new();
         variables_config.insert(
             "api_key".to_string(),
             crate::config::variable::VariableConfig {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1,5 +1,4 @@
-use std::collections::BTreeMap;
-
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use super::variable::{VariableConfig, VariableType};
@@ -10,7 +9,7 @@ pub struct TemplateConfig {
     pub template: TemplateMetadata,
 
     #[serde(default)]
-    pub variables: BTreeMap<String, VariableConfig>,
+    pub variables: IndexMap<String, VariableConfig>,
 
     #[serde(default)]
     pub files: FilesConfig,

--- a/src/prompt/engine.rs
+++ b/src/prompt/engine.rs
@@ -300,11 +300,13 @@ fn toml_to_tera_value(val: &toml::Value) -> Value {
 
 #[cfg(test)]
 mod tests {
+    use indexmap::IndexMap;
+
     use super::*;
     use rstest::rstest;
 
     /// Helper to create a minimal TemplateConfig for testing
-    fn minimal_config(variables: BTreeMap<String, VariableConfig>) -> TemplateConfig {
+    fn minimal_config(variables: IndexMap<String, VariableConfig>) -> TemplateConfig {
         TemplateConfig {
             template: crate::config::schema::TemplateMetadata {
                 name: "test".to_string(),
@@ -323,7 +325,7 @@ mod tests {
     /// Integration test: verify basic variable collection with defaults and multiple types
     #[test]
     fn test_collect_variables_multiple() {
-        let mut variables = BTreeMap::new();
+        let mut variables = IndexMap::new();
         variables.insert(
             "name".to_string(),
             VariableConfig {
@@ -388,7 +390,7 @@ mod tests {
     #[case("1", true)]
     #[case("0", false)]
     fn test_boolean_override_coercion(#[case] input: &str, #[case] expected: bool) {
-        let mut variables = BTreeMap::new();
+        let mut variables = IndexMap::new();
         variables.insert(
             "enabled".to_string(),
             VariableConfig {
@@ -427,7 +429,7 @@ mod tests {
         #[case] expected_len: usize,
         #[case] expected_value: Option<&str>,
     ) {
-        let mut variables = BTreeMap::new();
+        let mut variables = IndexMap::new();
         variables.insert(
             "enable_feature".to_string(),
             VariableConfig {
@@ -479,7 +481,7 @@ mod tests {
     /// Integration test: verify computed variables can reference other variables
     #[test]
     fn test_computed_variable_depends_on_another() {
-        let mut variables = BTreeMap::new();
+        let mut variables = IndexMap::new();
         variables.insert(
             "author".to_string(),
             VariableConfig {
@@ -540,7 +542,7 @@ mod tests {
     /// Integration test: verify Tera errors in computed variables are caught and wrapped
     #[test]
     fn test_computed_variable_evaluation_error() {
-        let mut variables = BTreeMap::new();
+        let mut variables = IndexMap::new();
         variables.insert(
             "broken".to_string(),
             VariableConfig {


### PR DESCRIPTION
## Summary

Prompts for values while interactive were not ordered as they appear in the diecut.toml file. They appeared to be the alphabetically order instead.

## Root cause

`src/config/schema.rs` used `BTreeMap` for the `variables` field. `BTreeMap` discards insertion order and sorts keys alphabetically, and the prompt engine iterates over this sorted order.

## Fix

Replace `BTreeMap` with `IndexMap`. 