### PR TITLE
fix: propagate read_dir error instead of silently treating it as empty dir

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,9 +115,15 @@ pub fn plan_generation(options: GenerateOptions) -> Result<FullGenerationPlan> {
 
     if output_dir.exists() && !options.overwrite {
         // An empty dir is fine
-        let has_contents = std::fs::read_dir(&output_dir)
-            .map(|mut d| d.next().is_some())
-            .unwrap_or(false);
+        let has_contents = match std::fs::read_dir(&output_dir) {
+            Ok(mut d) => d.next().is_some(),
+            Err(e) => {
+                return Err(DicecutError::Io {
+                    context: format!("reading output directory {}", output_dir.display()),
+                    source: e,
+                });
+            }
+        };
         if has_contents {
             return Err(DicecutError::OutputExists { path: output_dir });
         }


### PR DESCRIPTION
Replaces unwrap_or(false) on read_dir with an explicit match that propagates IO errors. A PermissionDenied (or any other) error on the output directory now returns DicecutError::Io with context instead of silently proceeding as if the directory were empty.