### PR TITLE
refactor: extract eval_bool_expr helper, fix error variant in walker

### DIFF
--- a/src/render/context.rs
+++ b/src/render/context.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use tera::{Context, Value};
+use tera::{Context, Tera, Value};
 
 pub fn build_context(variables: &BTreeMap<String, Value>) -> Context {
     let mut context = Context::new();
@@ -8,4 +8,16 @@ pub fn build_context(variables: &BTreeMap<String, Value>) -> Context {
         context.insert(key, value);
     }
     context
+}
+
+/// Evaluate a Tera boolean expression against a variable context.
+///
+/// Returns `Ok(true)` if the expression evaluates to true, `Ok(false)` otherwise.
+/// Returns `Err` if the expression fails to parse or render.
+pub fn eval_bool_expr(expr: &str, context: &Context) -> std::result::Result<bool, tera::Error> {
+    let mut tera = Tera::default();
+    let template_str = format!("{{% if {expr} %}}true{{% else %}}false{{% endif %}}");
+    tera.add_raw_template("__when__", &template_str)?;
+    let result = tera.render("__when__", context)?;
+    Ok(result.trim() == "true")
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2,7 +2,7 @@ pub mod context;
 pub mod file;
 pub mod walker;
 
-pub use context::build_context;
+pub use context::{build_context, eval_bool_expr};
 pub use walker::{
     execute_plan, plan_render, walk_and_render, GeneratedProject, GenerationPlan, PlannedFile,
 };


### PR DESCRIPTION
Extracts eval_bool_expr into render::context as the single implementation of Tera boolean expression evaluation. 

evaluate_when (engine.rs) and evaluate_when_expr (walker.rs) were functionally identical but had drifted: the walker was wrapping errors in DicecutError::RenderError with a synthetic filename, giving users misleading help text for files.conditional when failures. 

Both now use DicecutError::WhenEvaluation. evaluate_when and evaluate_computed also now use build_context instead of manual Context construction loops.