### PR TITLE
perf: use Tera::one_off in render_path_component

### DIFF
--- a/src/render/file.rs
+++ b/src/render/file.rs
@@ -14,19 +14,10 @@ pub fn render_file_content(tera: &Tera, template_name: &str, context: &Context) 
 
 /// Render template expressions in a path component (e.g. `{{project_name}}`).
 pub fn render_path_component(component: &str, context: &Context) -> Result<String> {
-    let mut tera = Tera::default();
-    tera.add_raw_template("__path__", component).map_err(|e| {
-        DicecutError::FilenameRenderError {
-            filename: component.to_string(),
-            source: e,
-        }
-    })?;
-
-    tera.render("__path__", context)
-        .map_err(|e| DicecutError::FilenameRenderError {
-            filename: component.to_string(),
-            source: e,
-        })
+    Tera::one_off(component, context, false).map_err(|e| DicecutError::FilenameRenderError {
+        filename: component.to_string(),
+        source: e,
+    })
 }
 
 /// Detect binary files using content_inspector (BOM-aware, null-byte scanning).


### PR DESCRIPTION
Every time diecut renders a file path that contains a template expression — for example `{{project_name}}/README.md` — it was spinning up a full Tera engine, registering the template, rendering it, then throwing the engine away. For a template with many files this happens once per path component in the loop.

Replaced with `Tera::one_off`, which is a static helper in the Tera library designed exactly for this one-shot case. Fewer allocations, same result.