### PR TITLE
refactor: replace SourceInfo with TemplateOrigin enum

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -219,16 +219,11 @@ fn test_answers_file_written() {
     let output_dir = tempfile::tempdir().unwrap();
     walk_and_render(&resolved, output_dir.path(), &variables, &context).unwrap();
 
-    let source_info = diecut::answers::SourceInfo {
-        url: None,
-        git_ref: None,
-        commit_sha: None,
-    };
     diecut::answers::write_answers(
         output_dir.path(),
         &resolved.config,
         &variables,
-        &source_info,
+        &diecut::answers::TemplateOrigin::Local,
     )
     .unwrap();
 


### PR DESCRIPTION
Whether a template came from a git repo or a local path was encoded by convention: if all three fields of `SourceInfo` are `None`, it's local; if `url` is set, it's from git. The hook-warning check read `source_info.url.is_some()` as a proxy for "is this a remote template?" That's implicit and easy to misread.

Replaced `SourceInfo` with an explicit enum:

```rust
pub enum TemplateOrigin {
    Local,
    Git { url: String, git_ref: Option<String>, commit_sha: Option<String> },
}
```

The hook-warning check is now `matches!(origin, TemplateOrigin::Git { .. })`, which says what it means. Construction sites in `plan_generation` and the integration test updated accordingly.