### PR TITLE
refactor: make origin private, remove unused template_dir from FullGenerationPlan

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,7 @@ pub struct FullGenerationPlan {
     pub output_dir: PathBuf,
     pub config: crate::config::schema::TemplateConfig,
     pub variables: BTreeMap<String, Value>,
-    pub origin: TemplateOrigin,
-    pub template_dir: PathBuf,
+    origin: TemplateOrigin,
     pub no_hooks: bool,
 }
 
@@ -143,7 +142,6 @@ pub fn plan_generation(options: GenerateOptions) -> Result<FullGenerationPlan> {
         config: resolved.config,
         variables,
         origin,
-        template_dir,
         no_hooks: options.no_hooks,
     })
 }


### PR DESCRIPTION
`FullGenerationPlan` had all fields public, but `source_info` (now `origin` after #99) and `template_dir` are only ever used inside `execute_generation`. No external caller has any reason to read or modify them.

`origin` is made private. `template_dir` turned out to never be read during execution at all — the template directory is resolved before the plan is built and isn't needed again — so it's removed from the struct entirely rather than just made private.